### PR TITLE
Update math syntax group names

### DIFF
--- a/tex.snippets
+++ b/tex.snippets
@@ -1,5 +1,5 @@
 global !p
-texMathZones = ['texMathZone' + x for x in ['A', 'AS', 'B', 'BS', 'C', 'CS', 'D', 'DS', 'E', 'ES', 'F', 'FS', 'G', 'GS', 'H', 'HS', 'I', 'IS', 'J', 'JS', 'K', 'KS', 'L', 'LS', 'V', 'W', 'X', 'Y', 'Z', 'AmsA', 'AmsAS', 'AmsB', 'AmsBS', 'AmsC', 'AmsCS', 'AmsD', 'AmsDS', 'AmsE', 'AmsES', 'AmsF', 'AmsFS', 'AmsG', 'AmsGS']]
+texMathZones = ['texMathZone' + x for x in ['A', 'AS', 'B', 'BS', 'C', 'CS', 'D', 'DS', 'E', 'ES', 'F', 'FS', 'G', 'GS', 'H', 'HS', 'I', 'IS', 'J', 'JS', 'K', 'KS', 'L', 'LS', 'V', 'W', 'X', 'Y', 'Z', 'AmsA', 'AmsAS', 'AmsB', 'AmsBS', 'AmsC', 'AmsCS', 'AmsD', 'AmsDS', 'AmsE', 'AmsES', 'AmsF', 'AmsG', 'AmsGS', 'BreqnA', 'BreqnAS', 'BreqnB', 'BreqnBS', 'BreqnC', 'BreqnCS', 'BreqnD', 'BreqnDS']]
 
 texIgnoreMathZones = ['texMathText']
 

--- a/tex.snippets
+++ b/tex.snippets
@@ -1,5 +1,5 @@
 global !p
-texMathZones = ['texMathZone'+x for x in ['A', 'AS', 'B', 'BS', 'C', 'CS', 'D', 'DS', 'E', 'ES', 'F', 'FS', 'G', 'GS', 'H', 'HS', 'I', 'IS', 'J', 'JS', 'K', 'KS', 'L', 'LS', 'DS', 'V', 'W', 'X', 'Y', 'Z']]
+texMathZones = ['texMathZone' + x for x in ['A', 'AS', 'B', 'BS', 'C', 'CS', 'D', 'DS', 'E', 'ES', 'F', 'FS', 'G', 'GS', 'H', 'HS', 'I', 'IS', 'J', 'JS', 'K', 'KS', 'L', 'LS', 'V', 'W', 'X', 'Y', 'Z', 'AmsA', 'AmsAS', 'AmsB', 'AmsBS', 'AmsC', 'AmsCS', 'AmsD', 'AmsDS', 'AmsE', 'AmsES', 'AmsF', 'AmsFS', 'AmsG', 'AmsGS']]
 
 texIgnoreMathZones = ['texMathText']
 


### PR DESCRIPTION
See lervag/vimtex@1ccaf71 and lervag/vimtex@1ccaf71. The syntax group names of AMSmath packages has been changed to `texMathZoneAms*`. There are also some new syntax groups added for breqn.

`texMathZoneE` to `texMathZoneM` might be deprecated but I'll just leave them there for backward compatibility.