### PR TITLE
Escape $ in snippet bodies

### DIFF
--- a/tex.snippets
+++ b/tex.snippets
@@ -107,7 +107,7 @@ snippet iff "iff" Ai
 endsnippet
 
 snippet mk "Math" wA
-$${1}$`!p
+\$${1}\$`!p
 if t[2] and t[2][0] not in [',', '.', '?', '-', ' ']:
 	snip.rv = ' '
 else:
@@ -629,7 +629,7 @@ snippet "([a-zA-Z])hat" "hat" riA
 endsnippet
 
 snippet letw "let omega" iA
-Let $\Omega \subset \C$ be open.
+Let \$\Omega \subset \C\$ be open.
 endsnippet
 
 


### PR DESCRIPTION
For some reason UltiSnips insert these snippets without any problems, however the documentation (`:h UltiSnips-character-escaping`) says this:
```vimdocs
 4.1.4 Character Escaping:                     *UltiSnips-character-escaping*

In snippet definitions, the characters '`', '{', '$' and '\' have special
meaning. If you want to insert one of these characters literally, escape them
with a backslash, '\'.
```
So I think it's better to escape the `$`s :)