### PR TITLE
Add tab triggered  calculation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+sympy
+latex2sympy2

--- a/tex.snippets
+++ b/tex.snippets
@@ -202,65 +202,37 @@ endsnippet
 
 priority 10000
 context "math()"
-snippet '^(.*(?:= |\$))(.*)[^\s=]\s*$' "latex-sympy-calculator-inline" wr
+snippet '^(.*(?:= |\$))(.*[^\s=])\s*$' "latex-sympy-calculator-expression" wr
 `!p
+import re
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import simplify
 prefix = match.group(1)
 code = match.group(2)
-from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
-from sympy import *
-from sympy.abc import *
+reg = re.match(r'^(.*)\&\s*=(?:.*)$', prefix)
+sep = '\n' + ' ' * len(reg.group(1)) + '&= ' if reg else ' = '
 try:
-	snip.rv = prefix + code + ' = ' + latex(factor(latex2sympy(code).subs(variances)))
+	snip.rv = prefix + code + sep + latex(simplify(latex2sympy(code).subs(variances)))
 except:
-	snip.rv = prefix + code + ' = '
+	snip.rv = prefix + code + sep
 `
 endsnippet
 
 priority 10000
 context "math()"
-snippet '^(.*(?:&\s?=))(.*)[^\s=]\s*$' "latex-sympy-calculator-block" wr
+snippet '^(.*(?:= |\$))(.*)=\s*$' "latex-sympy-calculator-numeric" wr
 `!p
+import re
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import simplify
 prefix = match.group(1)
 code = match.group(2)
-from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
-from sympy import *
-from sympy.abc import *
+reg = re.match(r'^(.*)\&\s*=(?:.*)$', prefix)
+sep = '\n' + ' ' * len(reg.group(1)) + '&= ' if reg else ' = '
 try:
-	snip.rv = prefix + code + '\n&= ' + latex(factor(latex2sympy(code).subs(variances)))
+	snip.rv = prefix + code + sep + latex(simplify(latex2sympy(code).subs(variances).doit().doit()).evalf(subs=variances))
 except:
-	snip.rv = prefix + code + '\n&= '
-`
-endsnippet
-
-priority 10000
-context "math()"
-snippet '^(.*(?:= |\$))(.*)=\s*$' "latex-sympy-calculator-inline-numeric" wr
-`!p
-prefix = match.group(1)
-code = match.group(2)
-from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
-from sympy import *
-from sympy.abc import *
-try:
-	snip.rv = prefix + code + '= ' + latex(simplify(latex2sympy(code).subs(variances).doit().doit()).evalf(subs=variances))
-except:
-	snip.rv = prefix + code + '= '
-`
-endsnippet
-
-priority 10000
-context "math()"
-snippet '^(.*(?:&\s?=))(.*)=\s*$' "latex-sympy-calculator-block" wr
-`!p
-prefix = match.group(1)
-code = match.group(2)
-from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
-from sympy import *
-from sympy.abc import *
-try:
-	snip.rv = prefix + code + '\n&= ' + latex(simplify(latex2sympy(code).subs(variances).doit().doit()).evalf(subs=variances))
-except:
-	snip.rv = prefix + code + '\n&= '
+	snip.rv = prefix + code + sep
 `
 endsnippet
 

--- a/tex.snippets
+++ b/tex.snippets
@@ -200,6 +200,18 @@ snip.rv = subprocess.check_output(['wolframscript', '-code', code])
 `
 endsnippet
 
+priority 10000                                                                                                   
+snippet '^(.*(?:= |\$))(.*)=?\s*$' "latex-sympy-calculator-expression" wr                                          
+`!p                                                                                                              
+prefix = match.group(1)
+code = match.group(2)
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import *
+from sympy.abc import *
+snip.rv = prefix + code + ' = ' + latex(factor(latex2sympy(code).subs(variances)))
+`                        
+endsnippet
+
 snippet == "equals" iA
 &= $1 \\\\
 endsnippet

--- a/tex.snippets
+++ b/tex.snippets
@@ -200,16 +200,68 @@ snip.rv = subprocess.check_output(['wolframscript', '-code', code])
 `
 endsnippet
 
-priority 10000                                                                                                   
-snippet '^(.*(?:= |\$))(.*)=?\s*$' "latex-sympy-calculator-expression" wr                                          
-`!p                                                                                                              
+priority 10000
+context "math()"
+snippet '^(.*(?:= |\$))(.*)[^\s=]\s*$' "latex-sympy-calculator-inline" wr
+`!p
 prefix = match.group(1)
 code = match.group(2)
 from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
 from sympy import *
 from sympy.abc import *
-snip.rv = prefix + code + ' = ' + latex(factor(latex2sympy(code).subs(variances)))
-`                        
+try:
+	snip.rv = prefix + code + ' = ' + latex(factor(latex2sympy(code).subs(variances)))
+except:
+	snip.rv = prefix + code + ' = '
+`
+endsnippet
+
+priority 10000
+context "math()"
+snippet '^(.*(?:&\s?=))(.*)[^\s=]\s*$' "latex-sympy-calculator-block" wr
+`!p
+prefix = match.group(1)
+code = match.group(2)
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import *
+from sympy.abc import *
+try:
+	snip.rv = prefix + code + '\n&= ' + latex(factor(latex2sympy(code).subs(variances)))
+except:
+	snip.rv = prefix + code + '\n&= '
+`
+endsnippet
+
+priority 10000
+context "math()"
+snippet '^(.*(?:= |\$))(.*)=\s*$' "latex-sympy-calculator-inline-numeric" wr
+`!p
+prefix = match.group(1)
+code = match.group(2)
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import *
+from sympy.abc import *
+try:
+	snip.rv = prefix + code + '= ' + latex(simplify(latex2sympy(code).subs(variances).doit().doit()).evalf(subs=variances))
+except:
+	snip.rv = prefix + code + '= '
+`
+endsnippet
+
+priority 10000
+context "math()"
+snippet '^(.*(?:&\s?=))(.*)=\s*$' "latex-sympy-calculator-block" wr
+`!p
+prefix = match.group(1)
+code = match.group(2)
+from latex2sympy2 import latex2latex, latex2sympy, var, variances, set_variances, set_real, latex
+from sympy import *
+from sympy.abc import *
+try:
+	snip.rv = prefix + code + '\n&= ' + latex(simplify(latex2sympy(code).subs(variances).doit().doit()).evalf(subs=variances))
+except:
+	snip.rv = prefix + code + '\n&= '
+`
 endsnippet
 
 snippet == "equals" iA


### PR DESCRIPTION
I really appreciate the idea of inline calculation as provided by sympy and mma, and I've noticed a package named "latex2sympy2", which converts LaTeX expressions directly into sympy and makes it possible to calculate right after typing an expression!

Examples:

```latex
% before
$x=\int_0^1 \mathrm{d}x = $ % add a '=' at the end before tab for numeric calculation
                            % otherwise for simplification
% after
$x=\int_0^1 \mathrm{d}x = 0.5$

% before
\begin{align*}    
    x &= 123 * 456 % tab here
.\end{align*}

% after
\begin{align*}
    x &= 123 * 456
      &= 56088
.\end{align*}

% before
\begin{align*}    
    x &= \frac{y^2}{y} % tab here
.\end{align*}

% after
\begin{align*}    
    x &= \frac{y^2}{y}
      &= y
.\end{align*}
```
